### PR TITLE
change tstl dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "HashMultiMapCollection"
   ],
   "dependencies": {
-    "tstl": "^2.2.3"
+    "tstl": "~2.2.3"
   },
   "devDependencies": {
     "@types/node": "^9.4.7"

--- a/src/maps/internal.ts
+++ b/src/maps/internal.ts
@@ -1,7 +1,7 @@
 import { EventDispatcher } from "../basic/EventDispatcher";
 
-import { MapElementList } from "tstl/internal/container/associative/MapElementList";
-import { MapElementVector } from "tstl/internal/container/associative/MapElementVector";
+import { MapElementList } from "tstl/base/container/MapElementList";
+import { MapElementVector } from "tstl/base/container/MapElementVector";
 
 for (let proto of [MapElementList.prototype, MapElementVector.prototype])
     Object.defineProperty(proto, "second",

--- a/src/maps/internal.ts
+++ b/src/maps/internal.ts
@@ -1,7 +1,7 @@
 import { EventDispatcher } from "../basic/EventDispatcher";
 
-import { MapElementList } from "tstl/base/container/MapElementList";
-import { MapElementVector } from "tstl/base/container/MapElementVector";
+import { MapElementList } from "tstl/internal/container/associative/MapElementList";
+import { MapElementVector } from "tstl/internal/container/associative/MapElementVector";
 
 for (let proto of [MapElementList.prototype, MapElementVector.prototype])
     Object.defineProperty(proto, "second",


### PR DESCRIPTION
only use version 2.2.3 of tstl dependency because of breaking changes introduced with commit 24be11a4b66a15f42e91d2f123a89a1fbefc285c on December 25th.